### PR TITLE
add terragrunt custom project name locals var injection

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -418,6 +418,9 @@ func createProject(sourcePath string) (*AtlantisProject, error) {
 	// We are going to use the same name for both workspace & project name as it is unique.
 	regex := regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 	projectName := regex.ReplaceAllString(project.Dir, "_")
+	if locals.AtlantisProjectName != "" {
+		projectName = locals.AtlantisProjectName
+	}
 
 	if createProjectName {
 		project.Name = projectName
@@ -563,6 +566,9 @@ func createHclProject(sourcePaths []string, workingDir string, projectHcl string
 	// We are going to use the same name for both workspace & project name as it is unique.
 	regex := regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 	projectName := regex.ReplaceAllString(project.Dir, "_")
+	if locals.AtlantisProjectName != "" {
+		projectName = locals.AtlantisProjectName
+	}
 
 	if createProjectName {
 		project.Name = projectName

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -235,6 +235,14 @@ func TestWithProjectNames(t *testing.T) {
 	})
 }
 
+func TestCustomProjectName(t *testing.T) {
+	runTest(t, filepath.Join("golden", "custom_project_name.yaml"), []string{
+		"--root",
+		filepath.Join("..", "test_examples", "custom_project_name"),
+		"--create-project-name",
+	})
+}
+
 func TestMergingLocalDependenciesFromParent(t *testing.T) {
 	runTest(t, filepath.Join("golden", "mergeParentDependencies.yaml"), []string{
 		"--root",

--- a/cmd/golden/custom_project_name.yaml
+++ b/cmd/golden/custom_project_name.yaml
@@ -1,0 +1,12 @@
+automerge: false
+parallel_apply: true
+parallel_plan: true
+projects:
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: projectA
+  name: project-a
+version: 3

--- a/cmd/golden/envhcl_allchilds.yaml
+++ b/cmd/golden/envhcl_allchilds.yaml
@@ -118,6 +118,12 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+  dir: custom_project_name/projectA
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
   dir: different_workflow_names/defaultWorkflow
 - autoplan:
     enabled: false

--- a/cmd/golden/envhcl_externalchilds.yaml
+++ b/cmd/golden/envhcl_externalchilds.yaml
@@ -118,6 +118,12 @@ projects:
     when_modified:
     - '*.hcl'
     - '*.tf*'
+  dir: custom_project_name/projectA
+- autoplan:
+    enabled: false
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
   dir: different_workflow_names/defaultWorkflow
 - autoplan:
     enabled: false

--- a/cmd/parse_locals.go
+++ b/cmd/parse_locals.go
@@ -21,6 +21,9 @@ type ResolvedLocals struct {
 	// The Atlantis workflow to use for some project
 	AtlantisWorkflow string
 
+	// The Atlantis project name to use for some project
+	AtlantisProjectName string
+
 	// Apply requirements to override the global `--apply-requirements` flag
 	ApplyRequirements []string
 
@@ -71,6 +74,10 @@ func parseHcl(parser *hclparse.Parser, hcl string, filename string) (file *hcl.F
 func mergeResolvedLocals(parent ResolvedLocals, child ResolvedLocals) ResolvedLocals {
 	if child.AtlantisWorkflow != "" {
 		parent.AtlantisWorkflow = child.AtlantisWorkflow
+	}
+
+	if child.AtlantisProjectName != "" {
+		parent.AtlantisProjectName = child.AtlantisProjectName
 	}
 
 	if child.TerraformVersion != "" {
@@ -143,6 +150,11 @@ func resolveLocals(localsAsCty cty.Value) ResolvedLocals {
 	workflowValue, ok := rawLocals["atlantis_workflow"]
 	if ok {
 		resolved.AtlantisWorkflow = workflowValue.AsString()
+	}
+
+	projectNameValue, ok := rawLocals["atlantis_project_name"]
+	if ok {
+		resolved.AtlantisProjectName = projectNameValue.AsString()
 	}
 
 	versionValue, ok := rawLocals["atlantis_terraform_version"]

--- a/test_examples/custom_project_name/projectA/terragrunt.hcl
+++ b/test_examples/custom_project_name/projectA/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  source = "git::git@github.com:transcend-io/terraform-aws-fargate-container?ref=v0.0.4"
+}
+
+locals {
+  atlantis_project_name = "project-a"
+}
+
+inputs = {
+  foo = "bar"
+}


### PR DESCRIPTION
This change will allow to generate atlantis.tf config files with a custom project name injected from the terragrunt locals block for each project (useful for atlantis -p flag) if the terragrunt-atlantis-config `--create-project-name` is being used.

example:

```hcl
locals {
  project_name = basename(get_terragrunt_dir())
  environment  = basename(dirname(get_terragrunt_dir()))

  # Atlantis setup
  atlantis_project_name = "${local.project_name}-${local.environment}"
}
```